### PR TITLE
Include 'libgen.h' in 'tape'

### DIFF
--- a/tools/tape/tape.c
+++ b/tools/tape/tape.c
@@ -2,6 +2,7 @@
 
 #include "libtrading/array.h"
 
+#include <libgen.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
`basename` is not declared on Darwin unless `libgen.h` is included.
