### PR TITLE
Add compatibility header to 'fix_perf'

### DIFF
--- a/tools/fix/fix_perf.c
+++ b/tools/fix/fix_perf.c
@@ -1,5 +1,6 @@
 #include <libtrading/proto/fix_message.h>
 #include <libtrading/buffer.h>
+#include <libtrading/compat.h>
 #include <libtrading/time.h>
 
 #include <libgen.h>


### PR DESCRIPTION
`fix_perf` uses `clock_gettime` which is provided by the compatibility layer on Darwin.
