### PR TITLE
Fix 'struct omx_itch186_message' name

### DIFF
--- a/include/libtrading/proto/omx_itch186_message.h
+++ b/include/libtrading/proto/omx_itch186_message.h
@@ -27,7 +27,7 @@ enum omx_itch186_msg_type {
 	OMX_ITCH186_MSG_NOII				= 'I', /* Section 4.8 */
 };
 
-struct omx_itch186_msg_message {
+struct omx_itch186_message {
 	u8			MessageType;
 } packed;
 


### PR DESCRIPTION
Rename `struct omx_itch186_msg_message` to `struct omx_itch186_message`. The latter name is already used elsewhere.

Note that this change most likely breaks all applications depending on Libtrading for Nordic Equity TotalView-ITCH version 1.86.
