### PR TITLE
fix_session_cfg_new: function to construct a fix configuration.

### DIFF
--- a/include/libtrading/proto/fix_session.h
+++ b/include/libtrading/proto/fix_session.h
@@ -72,6 +72,7 @@ static inline bool fix_msg_expected(struct fix_session *session, struct fix_mess
 	return msg->msg_seq_num == session->in_msg_seq_num || fix_message_type_is(msg, FIX_MSG_TYPE_SEQUENCE_RESET);
 }
 
+struct fix_session_cfg *fix_session_cfg_new(const char *sender_comp_id, const char *target_comp_id, int heartbtint, const char *dialect, int sockfd);
 struct fix_session *fix_session_new(struct fix_session_cfg *cfg);
 void fix_session_free(struct fix_session *self);
 int fix_session_time_update(struct fix_session *self);

--- a/lib/proto/fix_session.c
+++ b/lib/proto/fix_session.c
@@ -20,6 +20,36 @@ static const char *begin_strings[] = {
 	[FIX_4_0]	= "FIX.4.0",
 };
 
+struct fix_session_cfg *fix_session_cfg_new(
+	const char *sender_comp_id,
+	const char *target_comp_id,
+	int heartbtint,
+	const char *dialect,
+	int sockfd
+) {
+	struct fix_session_cfg *cfg;
+	enum fix_version version;
+
+	cfg = calloc(1, sizeof(struct fix_session_cfg));
+
+	strncpy(cfg->sender_comp_id, sender_comp_id, sizeof(cfg->sender_comp_id));
+	strncpy(cfg->target_comp_id, target_comp_id, sizeof(cfg->target_comp_id));
+
+	cfg->heartbtint = heartbtint;
+
+	version =
+		!strcmp(dialect, "fixt-1.1") ? FIXT_1_1 :
+		!strcmp(dialect, "fix-4.0")  ? FIX_4_0 :
+		!strcmp(dialect, "fix-4.1")  ? FIX_4_1 :
+		!strcmp(dialect, "fix-4.2")  ? FIX_4_2 :
+		!strcmp(dialect, "fix-4.3")  ? FIX_4_3 : FIX_4_4;
+	cfg->dialect = &fix_dialects[version];
+
+	cfg->sockfd = sockfd;
+
+	return cfg;
+}
+
 struct fix_session *fix_session_new(struct fix_session_cfg *cfg)
 {
 	struct fix_session *self = calloc(1, sizeof *self);


### PR DESCRIPTION
This is far from complete, but I was wondering what you guys would think of having a few functions like this to ease interacting with libtrading from other languages. For example, it's easy to call a C API from Julia, but interacting with C structs is a bit of a pain – it's much nicer if you can interact with C structs as opaque pointers.
