### PR TITLE
Allow user to patch in custom sendmsg and recv implementations.

### DIFF
--- a/include/libtrading/read-write.h
+++ b/include/libtrading/read-write.h
@@ -5,6 +5,15 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+typedef ssize_t (*io_recv_t)(int fd, void *buffer, size_t length, int flags);
+typedef ssize_t (*io_sendmsg_t)(int fd, struct iovec *iov, size_t length, int flags);
+
+ssize_t sys_recv(int fd, void *buffer, size_t length, int flags);
+ssize_t sys_sendmsg(int fd, struct iovec *iov, size_t length, int flags);
+
+extern io_recv_t io_recv;
+extern io_sendmsg_t io_sendmsg;
+
 ssize_t xread(int fd, void *buf, size_t count);
 ssize_t xwrite(int fd, const void *buf, size_t count);
 ssize_t xwritev(int fd, const struct iovec *iov, int iovcnt);

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -96,7 +96,7 @@ ssize_t buffer_recv(struct buffer *buf, int sockfd, size_t size, int flags)
 	if (count > size)
 		count = size;
 
-	len = recv(sockfd, end, count, flags);
+	len = io_recv(sockfd, end, count, flags);
 	if (len < 0)
 		return len;
 

--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -565,7 +565,6 @@ void fix_message_unparse(struct fix_message *self)
 int fix_message_send(struct fix_message *self, int sockfd, int flags)
 {
 	struct iovec iov[2];
-	struct msghdr msg;
 	int ret = 0;
 
 	TRACE(LIBTRADING_FIX_MESSAGE_SEND(self, sockfd, flags));
@@ -575,12 +574,7 @@ int fix_message_send(struct fix_message *self, int sockfd, int flags)
 	buffer_to_iovec(self->head_buf, &iov[0]);
 	buffer_to_iovec(self->body_buf, &iov[1]);
 
-	msg = (struct msghdr) {
-		.msg_iov	= iov,
-		.msg_iovlen	= 2,
-	};
-
-	if (sendmsg(sockfd, &msg, 0) < 0) {
+	if (io_sendmsg(sockfd, iov, 2, 0) < 0) {
 		ret = -1;
 		goto error_out;
 	}

--- a/lib/read-write.c
+++ b/lib/read-write.c
@@ -1,9 +1,27 @@
 #include "libtrading/read-write.h"
 
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
 #include <errno.h>
+
+ssize_t sys_recv(int fd, void *buffer, size_t length, int flags)
+{
+	return recv(fd, buffer, length, flags);
+}
+
+ssize_t sys_sendmsg(int fd, struct iovec *iov, size_t length, int flags)
+{
+	struct msghdr msg = (struct msghdr) {
+		.msg_iov	= iov,
+		.msg_iovlen	= length,
+	};
+	return sendmsg(fd, &msg, flags);
+}
+
+io_recv_t io_recv = &sys_recv;
+io_sendmsg_t io_sendmsg = &sys_sendmsg;
 
 /* Same as read(2) except that this function never returns EAGAIN or EINTR. */
 ssize_t xread(int fd, void *buf, size_t count)


### PR DESCRIPTION
Default versions just calling the system sendmsg and recv functions are supplied, leaving the library behaviorally identical by default. Being able to do this is helpful for integrating libtrading with other libraries or languages that have their own event loop and/or I/O subsystems. This pull request only applies to the FIX protocol; adding similar hooks for the FAST protocol is not difficult but more hooks may be required. 
