### PR TITLE
Exchange simulator: switch from epoll to libevent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ EXTRA_LIBS += $(shell sh -c 'pkg-config --libs glib-2.0')$
 
 EXTRA_LIBS += -lz
 
+EXTRA_LIBS += -levent
+
 EXTRA_LIBS += -lncurses
 
 ifeq ($(uname_S),Linux)


### PR DESCRIPTION
Hi Pekka,

Below is attempt to resolve our issue #23

Once working on this patch I noticed a sort of inconvenience which we have already spotted
but perhaps should spend some time to properly resolve it. As far as I see it, by using events
provided by libevent we have no chances to detect whether a socket was closed. In case
the socket is ready to be read or was closed ev_cb() is invoked but we couldn't distinguish
between these two cases. A normal application would rely on recv() return value for example
but we can't as fix_session_recv() returns a pointer but not an integer. Perhaps, we should
find a workaround or permanent solution here. We have to release a trader somehow once
is it disconnected trader_free()

Comment for commit:

In order to support market simulator on various
platforms a cross-platform techniques should be
used. In particular, epoll is not present on such
a platform as Darwin but libevent fills the gap.

Signed-off-by: Marat Stanichenko mstanichenko@gmail.com
