### PR TITLE
fix_message: implement fix_message_add_field; fix_get_field_{count,at}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,6 @@ LIB_H += proto/fast_feed.h
 LIB_H += proto/fast_message.h
 LIB_H += proto/fast_session.h
 LIB_H += proto/fix_message.h
-LIB_H += proto/fix_message.h
 LIB_H += proto/iex_fix.h
 LIB_H += proto/lse_itch_message.h
 LIB_H += proto/mbt_fix.h

--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -183,8 +183,13 @@ void fix_message_add_field(struct fix_message *msg, struct fix_field *field);
 
 void fix_message_unparse(struct fix_message *self);
 int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer);
+
+int fix_get_field_count(struct fix_message *self);
+struct fix_field *fix_get_field_at(struct fix_message *self, int index);
 struct fix_field *fix_get_field(struct fix_message *self, int tag);
+
 const char *fix_get_string(struct fix_field *field, char *buffer, unsigned long len);
+
 void fix_message_validate(struct fix_message *self);
 int fix_message_send(struct fix_message *self, int sockfd, int flags);
 

--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -408,6 +408,15 @@ fail:
 	return -1;
 }
 
+int fix_get_field_count(struct fix_message *self) {
+	return self->nr_fields;
+}
+
+struct fix_field *fix_get_field_at(struct fix_message *self, int i)
+{
+	return i < self->nr_fields ? &self->fields[i] : NULL;
+}
+
 struct fix_field *fix_get_field(struct fix_message *self, int tag)
 {
 	unsigned long i;
@@ -472,6 +481,14 @@ void fix_message_free(struct fix_message *self)
 
 	free(self->fields);
 	free(self);
+}
+
+void fix_message_add_field(struct fix_message *self, struct fix_field *field)
+{
+	if (self->nr_fields < FIX_MAX_FIELD_NUMBER) {
+		self->fields[self->nr_fields] = *field;
+		self->nr_fields++;
+	}
 }
 
 bool fix_message_type_is(struct fix_message *self, enum fix_msg_type type)


### PR DESCRIPTION
It looks like `fix_message_add_field` was added to `fix_message.h` in https://github.com/libtrading/libtrading/commit/2e8abc12f62318fe5bd696a5f6df44e70f2b4986 but never implemented it. This is a simple implementation. If there are already the maximum number of fields in a message, rather than corrupting the following memory, this just silently drops it – not great behavior, but it's better than memory corruption.

The `fix_get_field_count` function gives you the number of fields that a message has and `fix_get_field_at` gives the field in a message at a given index. Together, these allow you to iterate through a message object and get each field it contains.
