### PR TITLE
int fix_tag instead of fix_tag, new feature - continuing sessions from pre-specified sequence numbers

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -112,7 +112,7 @@ enum fix_tag {
 };
 
 struct fix_field {
-	enum fix_tag			tag;
+	int                             tag;
 	enum fix_type			type;
 
 	union {

--- a/include/libtrading/proto/fix_session.h
+++ b/include/libtrading/proto/fix_session.h
@@ -37,6 +37,9 @@ struct fix_session_cfg {
 	int			heartbtint;
 	struct fix_dialect	*dialect;
 	int			sockfd;
+        
+        unsigned long           in_msg_seq_num;
+        unsigned long           out_msg_seq_num;
 };
 
 struct fix_session {

--- a/lib/proto/fix_session.c
+++ b/lib/proto/fix_session.c
@@ -98,8 +98,8 @@ struct fix_session *fix_session_new(struct fix_session_cfg *cfg)
 	self->password		= cfg->password;
 	self->sockfd		= cfg->sockfd;
 	self->tr_pending	= 0;
-	self->in_msg_seq_num	= 0;
-	self->out_msg_seq_num	= 1;
+	self->in_msg_seq_num	= cfg->in_msg_seq_num  > 0 ? cfg->in_msg_seq_num  : 0;
+	self->out_msg_seq_num	= cfg->out_msg_seq_num > 1 ? cfg->out_msg_seq_num : 1;
 
 	return self;
 }


### PR DESCRIPTION
It's important to be able to use arbitrary numbers, not just something defined in fix_tag enum. Dialect enums specifically.