### PR TITLE
speculative unparse with partial replace

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -123,8 +123,11 @@ enum fix_tag {
 };
 
 struct fix_field {
-	int                             tag;
+	int				tag;
 	enum fix_type			type;
+
+	unsigned long			buf_off;
+	int				fixed_len;
 
 	union {
 		int64_t			int_value;
@@ -138,6 +141,17 @@ struct fix_field {
 	(struct fix_field) {				\
 		.tag		= t,			\
 		.type		= FIX_TYPE_INT,		\
+		.buf_off	= -1,			\
+		.fixed_len	= -1,			\
+		{ .int_value	= v },			\
+	}
+
+#define FIX_INT_FIXED_FIELD(t, v, l)			\
+	(struct fix_field) {				\
+		.tag		= t,			\
+		.type		= FIX_TYPE_INT,		\
+		.buf_off	= -1,			\
+		.fixed_len	= l,			\
 		{ .int_value	= v },			\
 	}
 
@@ -145,6 +159,17 @@ struct fix_field {
 	(struct fix_field) {				\
 		.tag		= t,			\
 		.type		= FIX_TYPE_STRING,	\
+		.buf_off	= -1,			\
+		.fixed_len	= -1,			\
+		{ .string_value	= s },			\
+	}
+
+#define FIX_STRING_FIXED_FIELD(t, s, l)			\
+	(struct fix_field) {				\
+		.tag		= t,			\
+		.type		= FIX_TYPE_STRING,	\
+		.buf_off	= -1,			\
+		.fixed_len	= l,			\
 		{ .string_value	= s },			\
 	}
 
@@ -152,6 +177,17 @@ struct fix_field {
 	(struct fix_field) {				\
 		.tag		= t,			\
 		.type		= FIX_TYPE_FLOAT,	\
+		.buf_off	= -1,			\
+		.fixed_len	= -1,			\
+		{ .float_value  = v },			\
+	}
+
+#define FIX_FLOAT_FIXED_FIELD(t, v, l)			\
+	(struct fix_field) {				\
+		.tag		= t,			\
+		.type		= FIX_TYPE_FLOAT,	\
+		.buf_off	= -1,			\
+		.fixed_len	= l,			\
 		{ .float_value  = v },			\
 	}
 
@@ -159,6 +195,8 @@ struct fix_field {
 	(struct fix_field) {				\
 		.tag		= t,			\
 		.type		= FIX_TYPE_CHECKSUM,	\
+		.buf_off	= -1,			\
+		.fixed_len	= 3,			\
 		{ .int_value	= v },			\
 	}
 
@@ -188,7 +226,19 @@ struct fix_message {
 	struct fix_field		*fields;
 };
 
+struct fix_message_unparse_context {
+	struct fix_field sender_comp_id;
+	struct fix_field target_comp_id;
+	struct fix_field begin_string;
+	struct fix_field sending_time;
+	struct fix_field body_length;
+	struct fix_field msg_seq_num;
+	struct fix_field check_sum;
+	struct fix_field msg_type;
+};
+
 bool fix_field_unparse(struct fix_field *self, struct buffer *buffer);
+bool fix_field_replace(struct fix_field *self, struct buffer *buffer);
 
 struct fix_message *fix_message_new(void);
 void fix_message_free(struct fix_message *self);
@@ -197,6 +247,9 @@ void fix_message_add_field(struct fix_message *msg, struct fix_field *field);
 
 void fix_message_unparse(struct fix_message *self);
 int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer);
+
+void fix_message_pre_unparse_fixed(struct fix_message *self, struct fix_message_unparse_context *ctx);
+void fix_message_replace_fixed(struct fix_message *self, struct fix_message_unparse_context *ctx);
 
 int fix_get_field_count(struct fix_message *self);
 struct fix_field *fix_get_field_at(struct fix_message *self, int index);

--- a/lib/stringencoders/modp_numtoa.c
+++ b/lib/stringencoders/modp_numtoa.c
@@ -48,6 +48,24 @@ size_t modp_itoa10(int32_t value, char* str)
     return (size_t)(wstr - str);
 }
 
+size_t modp_itoa10_zpad(int32_t value, char* str, int32_t fixed_len)
+{
+    char* wstr=str;
+    /* Take care of sign */
+    uint32_t uvalue = (value < 0) ? (uint32_t)(-value) : (uint32_t)(value);
+    /* Conversion. Number is reversed. */
+    do *wstr++ = (char)(48 + (uvalue % 10)); while(uvalue /= 10);
+    /* Pad with zeros */
+    for (fixed_len -= (wstr - str) + (value < 0 ? 1 : 0); fixed_len > 0; --fixed_len)
+    *wstr++ = '0';
+    /* Sign */
+    if (value < 0) *wstr++ = '-';
+
+    /* Reverse string */
+    strreverse(str, wstr - 1);
+    return (size_t)(wstr - str);
+}
+
 size_t modp_uitoa10(uint32_t value, char* str)
 {
     char* wstr=str;
@@ -302,6 +320,123 @@ size_t modp_dtoa2(double value, char* str, int prec)
     return (size_t)(wstr - str);
 }
 
+size_t modp_dtoa2_zpad(double value, char* str, int prec, int fixed_len)
+{
+    /* Hacky test for NaN
+     * under -fast-math this won't work, but then you also won't
+     * have correct nan values anyways.  The alternative is
+     * to link with libmath (bad) or hack IEEE double bits (bad)
+     */
+    if (! (value == value)) {
+        str[0] = 'n'; str[1] = 'a'; str[2] = 'n'; str[3] = '\0';
+        return (size_t) 3;
+    }
+
+    /* if input is larger than thres_max, revert to exponential */
+    const double thres_max = (double)(0x7FFFFFFF);
+
+    int count;
+    double diff = 0.0;
+    char* wstr = str;
+
+    if (prec < 0) {
+        prec = 0;
+    } else if (prec > 9) {
+        /* precision of >= 10 can lead to overflow errors */
+        prec = 9;
+    }
+
+
+    /* we'll work in positive values and deal with the
+       negative sign issue later */
+    int neg = 0;
+    if (value < 0) {
+        neg = 1;
+        value = -value;
+    }
+
+
+    int whole = (int) value;
+    double tmp = (value - whole) * powers_of_10[prec];
+    uint32_t frac = (uint32_t)(tmp);
+    diff = tmp - frac;
+
+    if (diff > 0.5) {
+        ++frac;
+        /* handle rollover, e.g.  case 0.99 with prec 1 is 1.0  */
+        if (frac >= powers_of_10[prec]) {
+            frac = 0;
+            ++whole;
+        }
+    } else if (diff == 0.5 && ((frac == 0) || (frac & 1))) {
+        /* if halfway, round up if odd, OR
+           if last digit is 0.  That last part is strange */
+        ++frac;
+    }
+
+    /* for very large numbers switch back to native sprintf for exponentials.
+       anyone want to write code to replace this? */
+    /*
+      normal printf behavior is to print EVERY whole number digit
+      which can be 100s of characters overflowing your buffers == bad
+    */
+    if (value > thres_max) {
+        sprintf(str, "%e", neg ? -value : value);
+        return strlen(str);
+    }
+
+    if (prec == 0) {
+        diff = value - whole;
+        if (diff > 0.5) {
+            /* greater than 0.5, round up, e.g. 1.6 -> 2 */
+            ++whole;
+        } else if (diff == 0.5 && (whole & 1)) {
+            /* exactly 0.5 and ODD, then round up */
+            /* 1.5 -> 2, but 2.5 -> 2 */
+            ++whole;
+        }
+
+        /* vvvvvvvvvvvvvvvvvvv  Diff from modp_dto2 */
+    } else if (frac) {
+        count = prec;
+        /*
+         * now do fractional part, as an unsigned number
+         * we know it is not 0 but we can have leading zeros, these
+         * should be removed
+         */
+        while (!(frac % 10)) {
+            --count;
+            frac /= 10;
+        }
+        /*^^^^^^^^^^^^^^^^^^^  Diff from modp_dto2 */
+
+        /* now do fractional part, as an unsigned number */
+        do {
+            --count;
+            *wstr++ = (char)(48 + (frac % 10));
+        } while (frac /= 10);
+        /* add extra 0s */
+        while (count-- > 0) *wstr++ = '0';
+        /* add decimal */
+        *wstr++ = '.';
+    }
+
+    /* do whole part
+     * Take care of sign
+     * Conversion. Number is reversed.
+     */
+    do *wstr++ = (char)(48 + (whole % 10)); while (whole /= 10);
+
+    /* Pad with zeros */
+    for (fixed_len -= (wstr - str) + neg; fixed_len > 0; --fixed_len)
+        *wstr++ = '0';
+
+    if (neg) {
+        *wstr++ = '-';
+    }
+    strreverse(str, wstr - 1);
+    return (size_t)(wstr - str);
+}
 
 #include "libtrading/config.h"
 

--- a/lib/stringencoders/modp_numtoa.h
+++ b/lib/stringencoders/modp_numtoa.h
@@ -40,6 +40,15 @@
  */
 size_t modp_itoa10(int32_t value, char* buf);
 
+/** \brief convert an signed integer to char buffer with leading zeroes padding
+ *         no C string terminator
+ *
+ * \param[in] value
+ * \param[out] buf the output buffer.  Should be 16 chars or more.
+ * \param[in] fixed_len
+ */
+size_t modp_itoa10_zpad(int32_t value, char* buf, int32_t fixed_len);
+
 /** \brief convert an unsigned integer to char buffer
  *
  * \param[in] value
@@ -93,6 +102,25 @@ size_t modp_dtoa(double value, char* buf, int precision);
  *    Can only be 0-9.
  */
 size_t modp_dtoa2(double value, char* buf, int precision);
+
+/** \brief convert a floating point number to char buffer with a
+ *         variable-precision format, and no trailing zeros but with leading
+ *         zero padding
+ *
+ * This is similar to "%.[0-9]f" in the printf style, except it will
+ * NOT include trailing zeros after the decimal point.  This type
+ * of format oddly does not exists with printf.
+ *
+ * If the input value is greater than 1<<31, then the output format
+ * will be switched exponential format.
+ *
+ * \param[in] value
+ * \param[out] buf  The allocated output buffer.  Should be 32 chars or more.
+ * \param[in] precision  Number of digits to the right of the decimal point.
+ *    Can only be 0-9.
+ * \param[in] fixed_len Number of digits (total) for zero padding.
+ */
+size_t modp_dtoa2_zpad(double value, char* buf, int precision, int fixed_len);
 
 /**
  * adds a 8-character hexadecimal representation of value


### PR DESCRIPTION
@penberg @mstanichenko what I'm trying to do here is to partially unparse changed fields of the FIX message.

the idea is to prepare message template and then instead of full unparse replace certain changeable fields (like order price, seq num, checksum, etc).

this commit is incomplete because I need to also hack somehow a way to save buffers (head & body) instead of using fix_session's rx buffers. but could you please review the proposed code changes? i'd love to hear your feedback & suggestions.

in terms of performance i've updated fix_perf.c to have one more case:
```
denis@dc3arb-12:libtrading$ taskset -c 7 ./tools/fix/fix_perf 100000
format/replace 100000 0.189658 µs/message
format     100000 0.371124 µs/message
parse      100000 0.144354 µs/message
```