### PR TITLE
optional checksum validation, bugfix in fix_perf - the message were empty / not parsing anything

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -188,6 +188,9 @@ struct fix_message {
 	struct fix_field		*fields;
 };
 
+#define FIX_PARSE_CONVENTIONAL	0x0
+#define FIX_PARSE_FAST		0x1
+
 bool fix_field_unparse(struct fix_field *self, struct buffer *buffer);
 
 struct fix_message *fix_message_new(void);
@@ -196,7 +199,7 @@ void fix_message_free(struct fix_message *self);
 void fix_message_add_field(struct fix_message *msg, struct fix_field *field);
 
 void fix_message_unparse(struct fix_message *self);
-int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer);
+int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer, int flags);
 
 int fix_get_field_count(struct fix_message *self);
 struct fix_field *fix_get_field_at(struct fix_message *self, int index);

--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -188,8 +188,9 @@ struct fix_message {
 	struct fix_field		*fields;
 };
 
-#define FIX_PARSE_CONVENTIONAL	0x0
-#define FIX_PARSE_FAST		0x1
+enum fix_parse_flag {
+	FIX_PARSE_NO_CSUM = 1UL << 0
+};
 
 bool fix_field_unparse(struct fix_field *self, struct buffer *buffer);
 
@@ -199,7 +200,7 @@ void fix_message_free(struct fix_message *self);
 void fix_message_add_field(struct fix_message *msg, struct fix_field *field);
 
 void fix_message_unparse(struct fix_message *self);
-int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer, int flags);
+int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer, unsigned long flags);
 
 int fix_get_field_count(struct fix_message *self);
 struct fix_field *fix_get_field_at(struct fix_message *self, int index);

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -53,7 +53,8 @@ void buffer_append(struct buffer *dst, struct buffer *src)
 	if (len > buffer_remaining(dst)) {
 		len = buffer_remaining(dst);
 	}
-	memcpy(dst->data + dst->start, dst->data + src->start, len);
+	memcpy(dst->data + dst->start, src->data + src->start, len);
+	dst->start += len;
 	dst->end += len;
 }
 

--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -323,7 +323,7 @@ static bool verify_checksum(struct fix_message *self, struct buffer *buffer)
  * - "CheckSum=" ("10=") is 3 bytes long
  * - "MsgType=" ("35=") is 3 bytes long
  */
-static int checksum(struct fix_message *self, struct buffer *buffer, int flags)
+static int checksum(struct fix_message *self, struct buffer *buffer, unsigned long flags)
 {
 	const char *start;
 	int offset;
@@ -343,7 +343,7 @@ static int checksum(struct fix_message *self, struct buffer *buffer, int flags)
 		goto exit;
 	}
 
-	if (flags & FIX_PARSE_FAST) {
+	if (flags & FIX_PARSE_NO_CSUM) {
 		ret = 0;
 		goto exit;
 	}
@@ -433,7 +433,7 @@ exit:
 	return ret;
 }
 
-int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer, int flags)
+int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer, unsigned long flags)
 {
 	unsigned long size;
 	const char *start;

--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -323,7 +323,7 @@ static bool verify_checksum(struct fix_message *self, struct buffer *buffer)
  * - "CheckSum=" ("10=") is 3 bytes long
  * - "MsgType=" ("35=") is 3 bytes long
  */
-static int checksum(struct fix_message *self, struct buffer *buffer)
+static int checksum(struct fix_message *self, struct buffer *buffer, int flags)
 {
 	const char *start;
 	int offset;
@@ -340,6 +340,11 @@ static int checksum(struct fix_message *self, struct buffer *buffer)
 	 */
 	if (buffer_size(buffer) + offset < self->body_length + 7) {
 		ret = FIX_MSG_STATE_PARTIAL;
+		goto exit;
+	}
+
+	if (flags & FIX_PARSE_FAST) {
+		ret = 0;
 		goto exit;
 	}
 
@@ -428,7 +433,7 @@ exit:
 	return ret;
 }
 
-int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer)
+int fix_message_parse(struct fix_message *self, struct fix_dialect *dialect, struct buffer *buffer, int flags)
 {
 	unsigned long size;
 	const char *start;
@@ -450,7 +455,7 @@ retry:
 	if (ret)
 		goto fail;
 
-	ret = checksum(self, buffer);
+	ret = checksum(self, buffer, flags);
 	if (ret)
 		goto fail;
 

--- a/lib/proto/fix_session.c
+++ b/lib/proto/fix_session.c
@@ -191,7 +191,7 @@ int fix_session_recv(struct fix_session *self, struct fix_message **res, int fla
 
 	TRACE(LIBTRADING_FIX_MESSAGE_RECV(msg, flags));
 
-	if (!fix_message_parse(msg, self->dialect, buffer)) {
+	if (!fix_message_parse(msg, self->dialect, buffer, 0)) {
 		self->rx_timestamp = self->now;
 		self->in_msg_seq_num++;
 		goto parsed;
@@ -214,7 +214,7 @@ int fix_session_recv(struct fix_session *self, struct fix_message **res, int fla
 		}
 	}
 
-	if (!fix_message_parse(msg, self->dialect, buffer)) {
+	if (!fix_message_parse(msg, self->dialect, buffer, 0)) {
 		self->rx_timestamp = self->now;
 		self->in_msg_seq_num++;
 		goto parsed;

--- a/tools/fix/fix_perf.c
+++ b/tools/fix/fix_perf.c
@@ -96,12 +96,26 @@ int main(int argc, char *argv[])
 
 	buffer_append(rx_buf, head_buf);
 	buffer_append(rx_buf, body_buf);
+	rx_buf->start = 0;
 	
 	clock_gettime(CLOCK_MONOTONIC, &start);
 
 	for (i = 0; i < count; i++) {
 		rx_buf->start = 0;
-		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf);
+		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, FIX_PARSE_FAST);
+	}
+
+	clock_gettime(CLOCK_MONOTONIC, &end);
+
+	elapsed_nsec = timespec_delta(&start, &end);
+
+	printf("%-10s %d %f µs/message\n", "parse/fast", count, (double)elapsed_nsec/(double)count/1000.0);
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+
+	for (i = 0; i < count; i++) {
+		rx_buf->start = 0;
+		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, 0);
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &end);

--- a/tools/fix/fix_perf.c
+++ b/tools/fix/fix_perf.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
 	for (i = 0; i < count; i++) {
 		rx_buf->start = 0;
-		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, FIX_PARSE_FAST);
+		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, FIX_PARSE_NO_CSUM);
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &end);


### PR DESCRIPTION
1. FLAG_PARSE_FAST would skip checksum validation
2. buffer_append was flawed parse benchmark did nothing as the input was empty