### PR TITLE
combined recv and parse flags in fix_session_recv, translation of libtrading recv flags to OS flags, rename some flags

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -196,7 +196,7 @@ struct fix_message {
 };
 
 enum fix_parse_flag {
-	FIX_PARSE_NO_CSUM = 1UL << 0
+	FIX_PARSE_FLAG_NO_CSUM = 1UL << 0
 };
 
 bool fix_field_unparse(struct fix_field *self, struct buffer *buffer);

--- a/include/libtrading/proto/fix_session.h
+++ b/include/libtrading/proto/fix_session.h
@@ -97,8 +97,8 @@ struct fix_session *fix_session_new(struct fix_session_cfg *cfg);
 void fix_session_free(struct fix_session *self);
 int fix_session_time_update_timespec(struct fix_session *self, struct timespec *ts);
 int fix_session_time_update(struct fix_session *self);
-int fix_session_send(struct fix_session *self, struct fix_message *msg, int flags);
-int fix_session_recv(struct fix_session *self, struct fix_message **msg, int flags);
+int fix_session_send(struct fix_session *self, struct fix_message *msg, unsigned long flags);
+int fix_session_recv(struct fix_session *self, struct fix_message **msg, unsigned long flags);
 bool fix_session_keepalive(struct fix_session *session, struct timespec *now);
 bool fix_session_admin(struct fix_session *session, struct fix_message *msg);
 int fix_session_logon(struct fix_session *session);
@@ -114,8 +114,12 @@ int fix_session_new_order_single(struct fix_session *session, struct fix_field* 
 int fix_session_execution_report(struct fix_session *session, struct fix_field *fields, long nr_fields);
 
 enum fix_send_flag {
-	FIX_FLAG_PRESERVE_MSG_NUM = 1UL << 0,
-	FIX_FLAG_PRESERVE_BUFFER  = 1UL << 1
+	FIX_SEND_FLAG_PRESERVE_MSG_NUM = 1UL << 0, // lower 16 bits
+	FIX_SEND_FLAG_PRESERVE_BUFFER  = 1UL << 1,
+};
+
+enum fix_recv_flag {
+	FIX_RECV_FLAG_MSG_DONTWAIT = 1UL << 16, // upper 16 bits
 };
 
 #endif

--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -344,7 +344,7 @@ static int checksum(struct fix_message *self, struct buffer *buffer, unsigned lo
 		goto exit;
 	}
 
-	if (flags & FIX_PARSE_NO_CSUM) {
+	if (flags & FIX_PARSE_FLAG_NO_CSUM) {
 		ret = 0;
 		goto exit;
 	}
@@ -663,7 +663,7 @@ int fix_message_send(struct fix_message *self, int sockfd, int flags)
 
 	TRACE(LIBTRADING_FIX_MESSAGE_SEND(self, sockfd, flags));
 
-	if (!(flags & FIX_FLAG_PRESERVE_BUFFER))
+	if (!(flags & FIX_SEND_FLAG_PRESERVE_BUFFER))
 		fix_message_unparse(self);
 
 	buffer_to_iovec(self->head_buf, &iov[0]);
@@ -675,7 +675,7 @@ int fix_message_send(struct fix_message *self, int sockfd, int flags)
 	}
 
 error_out:
-	if (!(flags & FIX_FLAG_PRESERVE_BUFFER)) {
+	if (!(flags & FIX_SEND_FLAG_PRESERVE_BUFFER)) {
 		self->head_buf = self->body_buf = NULL;
 	}
 

--- a/tools/fix/fix_client.c
+++ b/tools/fix/fix_client.c
@@ -146,7 +146,7 @@ static int fix_client_script(struct fix_session_cfg *cfg, struct fix_client_arg 
 
 	while (tosend_elem) {
 		if (tosend_elem->msg.msg_seq_num)
-			fix_session_send(session, &tosend_elem->msg, FIX_FLAG_PRESERVE_MSG_NUM);
+			fix_session_send(session, &tosend_elem->msg, FIX_SEND_FLAG_PRESERVE_MSG_NUM);
 		else
 			fix_session_send(session, &tosend_elem->msg, 0);
 
@@ -154,7 +154,7 @@ static int fix_client_script(struct fix_session_cfg *cfg, struct fix_client_arg 
 			goto next;
 
 retry:
-		if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0)
+		if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0)
 			goto retry;
 
 		fprintf(stdout, "< ");
@@ -241,7 +241,7 @@ static int fix_client_session(struct fix_session_cfg *cfg, struct fix_client_arg
 			break;
 		}
 
-		if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0) {
+		if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0) {
 			fprintmsg(stdout, msg);
 
 			if (fix_session_admin(session, msg))
@@ -352,7 +352,7 @@ static int fix_client_order(struct fix_session_cfg *cfg, struct fix_client_arg *
 		fix_session_new_order_single(session, fields, nr);
 
 retry:
-		if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0)
+		if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0)
 			goto retry;
 
 		if (!fix_message_type_is(msg, FIX_MSG_TYPE_EXECUTION_REPORT))

--- a/tools/fix/fix_perf.c
+++ b/tools/fix/fix_perf.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
 	for (i = 0; i < count; i++) {
 		rx_buf->start = 0;
-		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, FIX_PARSE_NO_CSUM);
+		fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, FIX_PARSE_FLAG_NO_CSUM);
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &end);

--- a/tools/fix/fix_server.c
+++ b/tools/fix/fix_server.c
@@ -38,7 +38,7 @@ static bool fix_server_logon(struct fix_session *session)
 	struct fix_message *msg;
 
 retry:
-	if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0)
+	if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0)
 		goto retry;
 
 	if (!fix_message_type_is(msg, FIX_MSG_TYPE_LOGON))
@@ -64,7 +64,7 @@ retry:
 	if (!session->active)
 		goto exit;
 
-	if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0)
+	if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0)
 		goto retry;
 
 	if (!fix_message_type_is(msg, FIX_MSG_TYPE_LOGOUT))
@@ -135,7 +135,7 @@ static int fix_server_script(struct fix_session_cfg *cfg, struct fix_server_arg 
 	expected_elem = cur_elem(c_container);
 
 	while (expected_elem) {
-		if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0)
+		if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0)
 			continue;
 
 		fprintf(stdout, "> ");
@@ -217,7 +217,7 @@ static int fix_server_session(struct fix_session_cfg *cfg, struct fix_server_arg
 	if (!session)
 		goto exit;
 
-	fix_session_recv(session, &msg, MSG_DONTWAIT);
+	fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT);
 
 	logon_msg	= (struct fix_message) {
 		.type		= FIX_MSG_TYPE_LOGON,
@@ -234,7 +234,7 @@ static int fix_server_session(struct fix_session_cfg *cfg, struct fix_server_arg
 	for (;;) {
 		struct fix_message logout_msg;
 
-		if (fix_session_recv(session, &msg, MSG_DONTWAIT) <= 0)
+		if (fix_session_recv(session, &msg, FIX_RECV_FLAG_MSG_DONTWAIT) <= 0)
 			continue;
 		else if (fix_message_type_is(msg, FIX_MSG_TYPE_NEW_ORDER_SINGLE)) {
 			fix_session_execution_report(session, fields, nr);


### PR DESCRIPTION
related to #84 in order to pass parse flags to fix_session_recv need to implement flag translation