### PR TITLE
option in fix_client to send few warmup orders before the main loop

### DIFF
--- a/tools/fix/fix_client.h
+++ b/tools/fix/fix_client.h
@@ -8,6 +8,7 @@ struct fix_client_arg {
 	const char *script;
 	const char *output;
 	int orders;
+	int warmup_orders;
 };
 
 struct fix_client_function {


### PR DESCRIPTION
the idea is to reduce influence of initial few messages which are typically have lots of latency