### PR TITLE
FIX: handle message types that are not in the FIX Standard

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -206,7 +206,8 @@ struct fix_message {
 };
 
 enum fix_parse_flag {
-	FIX_PARSE_FLAG_NO_CSUM = 1UL << 0
+	FIX_PARSE_FLAG_NO_CSUM = 1UL << 0,
+	FIX_PARSE_FLAG_NO_TYPE = 1UL << 1
 };
 
 int fix_atoi(const char *p, const char **end);


### PR DESCRIPTION
Hi guys,

The following commit is supposed to deal with issue #99
I rethink it a bit, so please have a look. Any comments are welcome.

Description:

In order to support messages which types are not in the FIX
standard we should properly deal with two primary operations,
namely sending and receiving:

* In order to send a messages of non-standard types a user
is supposed to use a general fix_session_send() function.
A user has to set msg->type to FIX_MSG_TYPE_UNKNOWN which
implies a type that is not a part of the FIX standard. Also
msg->msg_type should point to ANSI C string which makes a
type in the outgoing stream.

* In order to receive messages of non-standard types a
user is supposed to use a general fix_session_recv()
functionality. A user should raise FIX_PARSE_FLAG_NO_TYPE
flag up which makes the engine set msg->type to
FIX_MSG_TYPE_UNKNOWN and msg->msg_type would point to
the FIX-string which represents a type in the incoming
stream.