### PR TITLE
64 bit version of fix string parse. assign 64 bit value to FIX_INT_FIELD during parse

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -216,7 +216,7 @@ enum fix_parse_flag {
 	FIX_PARSE_FLAG_NO_TYPE = 1UL << 1
 };
 
-int fix_atoi(const char *p, const char **end);
+int64_t fix_atoi64(const char *p, const char **end);
 int fix_uatoi(const char *p, const char **end);
 
 bool fix_field_unparse(struct fix_field *self, struct buffer *buffer);

--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -94,9 +94,9 @@ enum fix_msg_type fix_msg_type_parse(const char *s, const char delim)
 	}
 }
 
-int fix_atoi(const char *p, const char **end)
+int64_t fix_atoi64(const char *p, const char **end)
 {
-	int ret = 0;
+	int64_t ret = 0;
 	bool neg = false;
 	if (*p == '-') {
 		neg = true;
@@ -285,7 +285,7 @@ retry:
 
 	switch (type) {
 	case FIX_TYPE_INT:
-		self->fields[nr_fields++] = FIX_INT_FIELD(tag, fix_atoi(tag_ptr, NULL));
+		self->fields[nr_fields++] = FIX_INT_FIELD(tag, fix_atoi64(tag_ptr, NULL));
 		goto retry;
 	case FIX_TYPE_FLOAT:
 		self->fields[nr_fields++] = FIX_FLOAT_FIELD(tag, strtod(tag_ptr, NULL));


### PR DESCRIPTION
required to receive large integers like OrderID for instance