### PR TITLE
add fix_session.h to installed headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ LIB_H += proto/fast_message.h
 LIB_H += proto/fast_session.h
 LIB_H += proto/fix_message.h
 LIB_H += proto/fix_template.h
+LIB_H += proto/fix_session.h
 LIB_H += proto/cme_globex_fix.h
 LIB_H += proto/ice_os_fix.h
 LIB_H += proto/micex_fix.h


### PR DESCRIPTION
Current Makefile wasn't installing fix_session.h. This behavior doesn't seem intentional since fast_session.h *is* installed.