### PR TITLE
rename packed typedef to ___packed___ as it conflicts with other includes using __attribute((packed))__ directly

### DIFF
--- a/include/libtrading/proto/bats_pitch_message.h
+++ b/include/libtrading/proto/bats_pitch_message.h
@@ -29,7 +29,7 @@ enum pitch_msg_type {
 struct pitch_message {
 	char			Timestamp[8];
 	u8			MessageType;
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_symbol_clear {
 	char			Timestamp[8];
@@ -46,7 +46,7 @@ struct pitch_msg_add_order_short {
 	char			StockSymbol[6];
 	char			Price[10];
 	char			Display;
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_add_order_long {
 	char			Timestamp[8];
@@ -58,7 +58,7 @@ struct pitch_msg_add_order_long {
 	char			Price[10];
 	char			Display;
 	char			ParticipantID[4];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_order_executed {
 	char			Timestamp[8];
@@ -66,14 +66,14 @@ struct pitch_msg_order_executed {
 	char			OrderID[12];
 	char			ExecutedShares[6];
 	char			ExecutionID[12];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_order_cancel {
 	char			Timestamp[8];
 	u8			MessageType;
 	char			OrderID[12];
 	char			CanceledShares[6];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_trade_short {
 	char			Timestamp[8];
@@ -84,7 +84,7 @@ struct pitch_msg_trade_short {
 	char			StockSymbol[6];
 	char			Price[10];
 	char			ExecutionID[12];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_trade_long {
 	char			Timestamp[8];
@@ -95,13 +95,13 @@ struct pitch_msg_trade_long {
 	char			StockSymbol[8];
 	char			Price[10];
 	char			ExecutionID[12];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_trade_break {
 	char			Timestamp[8];
 	u8			MessageType;
 	char			ExecutionID[12];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_trading_status {
 	char			Timestamp[8];
@@ -111,7 +111,7 @@ struct pitch_msg_trading_status {
 	char			RegSHOAction;
 	char			Reserved1;
 	char			Reserved2;
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_auction_update {
 	char			Timestamp[8];
@@ -123,7 +123,7 @@ struct pitch_msg_auction_update {
 	char			SellShares[10];
 	char			IndicativePrice[10];
 	char			AuctionOnlyPrice[10];
-} packed;
+} __attribute__((packed));
 
 struct pitch_msg_auction_summary {
 	char			Timestamp[8];
@@ -132,7 +132,7 @@ struct pitch_msg_auction_summary {
 	char			AuctionType;
 	char			Price[10];
 	char			Shares[10];
-} packed;
+} __attribute__((packed));
 
 struct pitch_message *pitch_message_decode(struct buffer *buf, unsigned long extra);
 

--- a/include/libtrading/proto/boe_message.h
+++ b/include/libtrading/proto/boe_message.h
@@ -60,7 +60,7 @@ struct boe_header {
 	u8				MessageType;
 	u8				MatchingUnit;
 	le32				SequenceNumber;
-} packed;
+} __attribute__((packed));
 
 struct boe_message {
 	struct boe_header		header;
@@ -127,7 +127,7 @@ struct boe_message {
 struct boe_unit {
 	u8				UnitNumber;
 	le32				UnitSequence;
-} packed;
+} __attribute__((packed));
 
 struct boe_login_request {
 	char				SessionSubID[4];
@@ -147,7 +147,7 @@ struct boe_login_request {
 	le64				ReservedBitfields2;
 	u8				NumberOfUnits;
 	struct boe_unit			Units[];
-} packed;
+} __attribute__((packed));
 
 /*
  * BATS to participant messages:
@@ -171,7 +171,7 @@ struct boe_login_response {
 	le32				LastReceivedSequenceNumber;
 	u8				NumberOfUnits;
 	struct boe_unit			Units[];
-} packed;
+} __attribute__((packed));
 
 struct boe_logout {
 	u8				LogoutReason;
@@ -179,7 +179,7 @@ struct boe_logout {
 	le32				LastReceivedSequenceNumber;
 	u8				NumberOfUnits;
 	struct boe_unit			Units[];
-} packed;
+} __attribute__((packed));
 
 int boe_message_decode(struct buffer *buf, struct boe_message *msg, size_t size);
 

--- a/include/libtrading/proto/lse_itch_message.h
+++ b/include/libtrading/proto/lse_itch_message.h
@@ -104,7 +104,7 @@ struct lse_itch_login_request {
 	u8			MessageType;
 	char			Username[6];
 	char			Password[8];
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_REPLAY_REQUEST */
 struct lse_itch_replay_request {
@@ -113,7 +113,7 @@ struct lse_itch_replay_request {
 	u8			MarketDataGroup;
 	le32			FirstMessage;
 	le16			Count;
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_SNAPSHOT_REQUEST */
 struct lse_itch_snapshot_request {
@@ -122,20 +122,20 @@ struct lse_itch_snapshot_request {
 	le32			SequenceNumber;
 	char			Segment[6];
 	le32			InstrumentID;
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_LOGOUT_REQUEST */
 struct lse_itch_logout_request {
 	u8			Length;
 	u8			MessageType;
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_LOGIN_RESPONSE */
 struct lse_itch_logout_response {
 	u8			Length;
 	u8			MessageType;
 	u8			Status;		/* See LSE_ITCH_LOGIN_STATUS enum */
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_REPLAY_RESPONSE */
 struct lse_itch_replay_response {
@@ -145,7 +145,7 @@ struct lse_itch_replay_response {
 	le32			FirstMessage;
 	le16			Count;
 	u8			Status;		/* See LSE_ITCH_REPLAY_STATUS enum */
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_SNAPSHOT_RESPONSE */
 struct lse_itch_snapshot_response {
@@ -154,7 +154,7 @@ struct lse_itch_snapshot_response {
 	le32			SequenceNumber;
 	le32			OrderCount;
 	u8			Status;		/* See LSE_ITCH_SNAPSHOT_STATUS enum */
-} packed;
+} __attribute__((packed));
 
 /* LSE_ITCH_MSG_SNAPSHOT_COMPLETE */
 struct lse_itch_snapshot_complete {
@@ -164,7 +164,7 @@ struct lse_itch_snapshot_complete {
 	char			Segment[6];
 	le32			InstrumentID;
 	u8			Flags;
-} packed;
+} __attribute__((packed));
 
 int lse_itch_message_decode(struct buffer *buf, struct lse_itch_message *msg);
 

--- a/include/libtrading/proto/nasdaq_itch40_message.h
+++ b/include/libtrading/proto/nasdaq_itch40_message.h
@@ -57,14 +57,14 @@ struct itch40_message {
 struct itch40_msg_timestamp_seconds {
 	u8			MessageType;
 	be32			Second;	
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_SYSTEM_EVENT */
 struct itch40_msg_system_event {
 	u8			MessageType;
 	be32			Timestamp;
 	char			EventCode;	/* ITCH40_EVENT_<code> */
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_STOCK_DIRECTORY */
 struct itch40_msg_stock_directory {
@@ -75,7 +75,7 @@ struct itch40_msg_stock_directory {
 	char			FinancialStatusIndicator;
 	be32			RoundLotSize;
 	char			RoundLotsOnly;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_STOCK_TRADING_ACTION */
 struct itch40_msg_stock_trading_action {
@@ -85,7 +85,7 @@ struct itch40_msg_stock_trading_action {
 	char			TradingState;
 	char			Reserved;
 	char			Reason[4];
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_MARKET_PARTICIPANT_POS */
 struct itch40_msg_market_participant_pos {
@@ -96,7 +96,7 @@ struct itch40_msg_market_participant_pos {
 	char			PrimaryMarketMaker;
 	char			MarketMakerMode;
 	char			MarketParticipantState;	
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ADD_ORDER */
 struct itch40_msg_add_order {
@@ -107,7 +107,7 @@ struct itch40_msg_add_order {
 	be32			Shares;
 	char			Stock[6];
 	be32			Price;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ADD_ORDER_MPID */
 struct itch40_msg_add_order_mpid {
@@ -119,7 +119,7 @@ struct itch40_msg_add_order_mpid {
 	char			Stock[6];
 	be32			Price;
 	char			Attribution[4];
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ORDER_EXECUTED */
 struct itch40_msg_order_executed {
@@ -128,7 +128,7 @@ struct itch40_msg_order_executed {
 	be64			OrderReferenceNumber;
 	be32			ExecutedShares;
 	be64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ORDER_EXECUTED_WITH_PRICE */
 struct itch40_msg_order_executed_with_price {
@@ -139,7 +139,7 @@ struct itch40_msg_order_executed_with_price {
 	be64			MatchNumber;
 	char			Printable;
 	be32			ExecutionPrice;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ORDER_CANCEL */
 struct itch40_msg_order_cancel {
@@ -147,14 +147,14 @@ struct itch40_msg_order_cancel {
 	be32			TimestampNanoseconds;
 	be64			OrderReferenceNumber;
 	be32			CanceledShares;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ORDER_DELETE */
 struct itch40_msg_order_delete {
 	u8			MessageType;
 	be32			TimestampNanoseconds;
 	be64			OrderReferenceNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_ORDER_REPLACE */
 struct itch40_msg_order_replace {
@@ -164,7 +164,7 @@ struct itch40_msg_order_replace {
 	be64			NewOrderReferenceNumber;
 	be32			Shares;
 	be32			Price;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_TRADE */
 struct itch40_msg_trade {
@@ -176,7 +176,7 @@ struct itch40_msg_trade {
 	char			Stock[6];
 	be32			Price;
 	be64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_CROSS_TRADE */
 struct itch40_msg_cross_trade {
@@ -187,14 +187,14 @@ struct itch40_msg_cross_trade {
 	be32			CrossPrice;
 	be64			MatchNumber;
 	char			CrossType;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_BROKEN_TRADE */
 struct itch40_msg_broken_trade {
 	u8			MessageType;
 	be32			TimestampNanoseconds;
 	be64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH40_MSG_NOII */
 struct itch40_msg_noii {
@@ -209,7 +209,7 @@ struct itch40_msg_noii {
 	be32			CurrentReferencePrice;
 	char			CrossType;
 	char			PriceVariationIndicator;
-} packed;
+} __attribute__((packed));
 
 int itch40_message_decode(struct buffer *buf, struct itch40_message *msg);
 

--- a/include/libtrading/proto/nasdaq_itch41_message.h
+++ b/include/libtrading/proto/nasdaq_itch41_message.h
@@ -59,14 +59,14 @@ struct itch41_message {
 struct itch41_msg_timestamp_seconds {
 	u8			MessageType;
 	be32			Second;	
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_SYSTEM_EVENT */
 struct itch41_msg_system_event {
 	u8			MessageType;
 	be32			Timestamp;
 	char			EventCode;	/* ITCH41_EVENT_<code> */
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_STOCK_DIRECTORY */
 struct itch41_msg_stock_directory {
@@ -77,7 +77,7 @@ struct itch41_msg_stock_directory {
 	char			FinancialStatusIndicator;
 	be32			RoundLotSize;
 	char			RoundLotsOnly;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_STOCK_TRADING_ACTION */
 struct itch41_msg_stock_trading_action {
@@ -87,7 +87,7 @@ struct itch41_msg_stock_trading_action {
 	char			TradingState;
 	char			Reserved;
 	char			Reason[4];
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_REG_SHO_RESTRICTION */
 struct itch41_msg_reg_sho_restriction {
@@ -95,7 +95,7 @@ struct itch41_msg_reg_sho_restriction {
 	be32			TimestampNanoseconds;
 	char			Stock[8];
 	char			RegSHOAction;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_MARKET_PARTICIPANT_POS */
 struct itch41_msg_market_participant_pos {
@@ -106,7 +106,7 @@ struct itch41_msg_market_participant_pos {
 	char			PrimaryMarketMaker;
 	char			MarketMakerMode;
 	char			MarketParticipantState;	
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ADD_ORDER */
 struct itch41_msg_add_order {
@@ -117,7 +117,7 @@ struct itch41_msg_add_order {
 	be32			Shares;
 	char			Stock[8];
 	be32			Price;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ADD_ORDER_MPID */
 struct itch41_msg_add_order_mpid {
@@ -129,7 +129,7 @@ struct itch41_msg_add_order_mpid {
 	char			Stock[8];
 	be32			Price;
 	char			Attribution[4];
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ORDER_EXECUTED */
 struct itch41_msg_order_executed {
@@ -138,7 +138,7 @@ struct itch41_msg_order_executed {
 	be64			OrderReferenceNumber;
 	be32			ExecutedShares;
 	be64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ORDER_EXECUTED_WITH_PRICE */
 struct itch41_msg_order_executed_with_price {
@@ -149,7 +149,7 @@ struct itch41_msg_order_executed_with_price {
 	be64			MatchNumber;
 	char			Printable;
 	be32			ExecutionPrice;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ORDER_CANCEL */
 struct itch41_msg_order_cancel {
@@ -157,14 +157,14 @@ struct itch41_msg_order_cancel {
 	be32			TimestampNanoseconds;
 	be64			OrderReferenceNumber;
 	be32			CanceledShares;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ORDER_DELETE */
 struct itch41_msg_order_delete {
 	u8			MessageType;
 	be32			TimestampNanoseconds;
 	be64			OrderReferenceNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_ORDER_REPLACE */
 struct itch41_msg_order_replace {
@@ -174,7 +174,7 @@ struct itch41_msg_order_replace {
 	be64			NewOrderReferenceNumber;
 	be32			Shares;
 	be32			Price;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_TRADE */
 struct itch41_msg_trade {
@@ -186,7 +186,7 @@ struct itch41_msg_trade {
 	char			Stock[8];
 	be32			Price;
 	be64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_CROSS_TRADE */
 struct itch41_msg_cross_trade {
@@ -197,14 +197,14 @@ struct itch41_msg_cross_trade {
 	be32			CrossPrice;
 	be64			MatchNumber;
 	char			CrossType;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_BROKEN_TRADE */
 struct itch41_msg_broken_trade {
 	u8			MessageType;
 	be32			TimestampNanoseconds;
 	be64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_NOII */
 struct itch41_msg_noii {
@@ -219,7 +219,7 @@ struct itch41_msg_noii {
 	be32			CurrentReferencePrice;
 	char			CrossType;
 	char			PriceVariationIndicator;
-} packed;
+} __attribute__((packed));
 
 /* ITCH41_MSG_RPII */
 struct itch41_msg_rpii {
@@ -227,7 +227,7 @@ struct itch41_msg_rpii {
 	be32			TimestampNanoseconds;
 	char			Stock[8];
 	char			InterestFlag;
-} packed;
+} __attribute__((packed));
 
 struct itch41_message *itch41_message_decode(struct buffer *buf);
 

--- a/include/libtrading/proto/nyse_taq_message.h
+++ b/include/libtrading/proto/nyse_taq_message.h
@@ -34,7 +34,7 @@ struct nyse_taq_msg_daily_quote {
 	char			LULDBBOIndicatorUTP;
 	char			FINRAADFMPIDIndicator;
 	char			LineChange[2];
-} packed;
+} __attribute__((packed));
 
 struct nyse_taq_msg_daily_trade {
 	char			Time[9];
@@ -49,7 +49,7 @@ struct nyse_taq_msg_daily_trade {
 	char			SourceOfTrade;
 	char			TradeReportingFacility;
 	char			LineChange[2];
-} packed;
+} __attribute__((packed));
 
 struct nyse_taq_msg_daily_nbbo {
 	char			Time[9];
@@ -84,7 +84,7 @@ struct nyse_taq_msg_daily_nbbo {
 	char			LULDNBBOIndicatorCQS;
 	char			LULDNBBOIndicatorUTP;
 	char			LineChange[2];
-} packed;
+} __attribute__((packed));
 
 void *nyse_taq_msg_decode(struct buffer *buf, size_t size);
 

--- a/include/libtrading/proto/omx_itch186_message.h
+++ b/include/libtrading/proto/omx_itch186_message.h
@@ -33,28 +33,28 @@ enum omx_itch186_msg_type {
 
 struct omx_itch186_message {
 	u8			MessageType;
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_seconds {
 	u8			MessageType;
 	char			Second[5];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_milliseconds {
 	u8			MessageType;
 	char			Millisecond[3];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_system_event {
 	u8			MessageType;
 	char			EventCode;
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_market_segment_state {
 	u8			MessageType;
 	char			MarketSegmentID[3];
 	char			EventCode;
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_order_book_directory {
 	u8			MessageType;
@@ -67,7 +67,7 @@ struct omx_itch186_msg_order_book_directory {
 	char			MarketSegmentID[3];
 	char			NoteCodes[8];
 	char			RoundLotSize[9];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_order_book_trading_action {
 	u8			MessageType;
@@ -75,7 +75,7 @@ struct omx_itch186_msg_order_book_trading_action {
 	char			TradingState;
 	char			Reserved;
 	char			Reason[4];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_add_order {
 	u8			MessageType;
@@ -84,7 +84,7 @@ struct omx_itch186_msg_add_order {
 	char			Quantity[9];
 	char			OrderBook[6];
 	char			Price[10];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_add_order_mpid {
 	u8			MessageType;
@@ -94,7 +94,7 @@ struct omx_itch186_msg_add_order_mpid {
 	char			OrderBook[6];
 	char			Price[10];
 	char			Attribution[4];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_order_executed {
 	u8			MessageType;
@@ -103,7 +103,7 @@ struct omx_itch186_msg_order_executed {
 	char			MatchNumber[9];
 	char			OwnerParticipantID[4];
 	char			CounterpartyParticipantID[4];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_order_executed_with_price {
 	u8			MessageType;
@@ -114,18 +114,18 @@ struct omx_itch186_msg_order_executed_with_price {
 	char			TradePrice[10];
 	char			OwnerParticipantID[4];
 	char			CounterpartyParticipantID[4];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_order_cancel {
 	u8			MessageType;
 	char			OrderReferenceNumber[9];
 	char			CanceledQuantity[9];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_order_delete {
 	u8			MessageType;
 	char			OrderReferenceNumber[9];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_trade {
 	u8			MessageType;
@@ -137,7 +137,7 @@ struct omx_itch186_msg_trade {
 	char			TradePrice[10];
 	char			BuyerParticipantID[4];
 	char			SellerParticipantID[4];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_cross_trade {
 	u8			MessageType;
@@ -147,12 +147,12 @@ struct omx_itch186_msg_cross_trade {
 	char			MatchNumber[9];
 	char			CrossType;
 	char			NumberOfTrades[10];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_broken_trade {
 	u8			MessageType;
 	char			MatchNumber[9];
-} packed;
+} __attribute__((packed));
 
 struct omx_itch186_msg_noii {
 	u8			MessageType;
@@ -166,7 +166,7 @@ struct omx_itch186_msg_noii {
 	char			BestBidQuantity[9];
 	char			BestAskPrice[10];
 	char			BestAskQuantity[9];
-} packed;
+} __attribute__((packed));
 
 unsigned long omx_itch186_message_size(u8 type);
 

--- a/include/libtrading/proto/omx_moldudp_message.h
+++ b/include/libtrading/proto/omx_moldudp_message.h
@@ -11,17 +11,17 @@ struct omx_moldudp_header {
 	char			Session[10];
 	le32			SequenceNumber;
 	le16			MessageCount;
-} packed;
+} __attribute__((packed));
 
 struct omx_moldudp_message {
 	le16			MessageLength;
-} packed;
+} __attribute__((packed));
 
 struct omx_moldudp_request {
 	char			Session[10];
 	le32			SequenceNumber;
 	le16			RequestedMessageCount;
-} packed;
+} __attribute__((packed));
 
 static inline struct omx_moldudp_message *omx_moldudp_payload(struct omx_moldudp_header *msg)
 {

--- a/include/libtrading/proto/ouch42_message.h
+++ b/include/libtrading/proto/ouch42_message.h
@@ -33,7 +33,7 @@ enum ouch42_msg_type {
 
 struct ouch42_message {
 	char			MessageType;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_enter_order {
 	char			MessageType;
@@ -49,7 +49,7 @@ struct ouch42_msg_enter_order {
 	char			IntermarketSweepEligibility;
 	u32			MinimumQuantity;
 	char			CrossType;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_replace_order {
 	u8			MessageType;
@@ -61,26 +61,26 @@ struct ouch42_msg_replace_order {
 	char			Display;
 	char			IntermarketSweepEligibility;
 	u32			MinimumQuantity;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_cancel_order {
 	u8			MessageType;
 	char			OrderToken[14];
 	u32			Shares;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_modify_order {
 	u8			MessageType;
 	char			OrderToken[14];
 	char			BuySellIndicator;
 	u32			Shares;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_system_event {
 	u8			MessageType;
 	u64			Timestamp;
 	char			EventCode;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_accepted {
 	u8			MessageType;
@@ -100,7 +100,7 @@ struct ouch42_msg_accepted {
 	char			CrossType;
 	char			OrderState;
 	char			BBOWeightIndicator;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_replaced {
 	u8			MessageType;
@@ -121,7 +121,7 @@ struct ouch42_msg_replaced {
 	char			OrderState;
 	char			PreviousOrderToken[14];
 	char			BBOWeightIndicator;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_canceled {
 	u8			MessageType;
@@ -129,7 +129,7 @@ struct ouch42_msg_canceled {
 	char			OrderToken[14];
 	u32			DecrementShares;
 	char			Reason;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_aiq_canceled {
 	u8			MessageType;
@@ -140,7 +140,7 @@ struct ouch42_msg_aiq_canceled {
 	u32			QuantityPreventedFromTrading;
 	u32			ExecutionPrice;
 	char			LiquidityFlag;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_executed {
 	u8			MessageType;
@@ -150,7 +150,7 @@ struct ouch42_msg_executed {
 	u32			ExecutionPrice;
 	char			LiquidityFlag;
 	u64			MatchNumber;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_broken_trade {
 	u8			MessageType;
@@ -158,26 +158,26 @@ struct ouch42_msg_broken_trade {
 	char			OrderToken[14];
 	u64			MatchNumber;
 	char			Reason;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_rejected {
 	u8			MessageType;
 	u64			Timestamp;
 	char			OrderToken[14];
 	char			Reason;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_cancel_pending {
 	u8			MessageType;
 	u64			Timestamp;
 	char			OrderToken[14];
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_cancel_reject {
 	u8			MessageType;
 	u64			Timestamp;
 	char			OrderToken[14];
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_order_prio_update {
 	u8			MessageType;
@@ -186,7 +186,7 @@ struct ouch42_msg_order_prio_update {
 	u32			Price;
 	char			Display;
 	u64			OrderReferenceNumber;
-} packed;
+} __attribute__((packed));
 
 struct ouch42_msg_order_modified {
 	u8			MessageType;
@@ -194,7 +194,7 @@ struct ouch42_msg_order_modified {
 	char			OrderToken[14];
 	char			BuySellIndicator;
 	u32			Shares;
-} packed;
+} __attribute__((packed));
 
 int ouch42_in_message_decode(struct buffer *buf, struct ouch42_message *msg);
 int ouch42_out_message_decode(struct buffer *buf, struct ouch42_message *msg);

--- a/include/libtrading/proto/soupbin3_session.h
+++ b/include/libtrading/proto/soupbin3_session.h
@@ -39,7 +39,7 @@ struct soupbin3_packet_debug {
 	be16			PacketLength;
 	char			PacketType;
 	char			Text[];
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_LOGIN_ACCEPTED */
 struct soupbin3_packet_login_accepted {
@@ -47,33 +47,33 @@ struct soupbin3_packet_login_accepted {
 	char			PacketType;
 	char			Session[10];
 	char			SequenceNumber[20];
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_LOGIN_REJECTED */
 struct soupbin3_packet_login_rejected {
 	be16			PacketLength;
 	char			PacketType;
 	char			RejectReasonCode;
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_SEQ_DATA */
 struct soupbin3_packet_seq_data {
 	be16			PacketLength;
 	char			PacketType;
 	char			Message[];
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_SERVER_HEARTBEAT */
 struct soupbin3_packet_server_heartbeat {
 	be16			PacketLength;
 	char			PacketType;
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_END_OF_SESSION */
 struct soupbin3_packet_end_of_session {
 	be16			PacketLength;
 	char			PacketType;
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_LOGIN_REQUEST */
 struct soupbin3_packet_login_request {
@@ -83,26 +83,26 @@ struct soupbin3_packet_login_request {
 	char			Password[10];
 	char			RequestedSession[10];
 	char			RequestedSequenceNumber[20];
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_UNSEQ_DATA */
 struct soupbin3_packet_unseq_data {
 	be16			PacketLength;
 	char			PacketType;
 	char			Message[];
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_CLIENT_HEARTBEAT */
 struct soupbin3_packet_client_heartbeat {
 	be16			PacketLength;
 	char			PacketType;
-} packed;
+} __attribute__((packed));
 
 /* SOUPBIN_PACKET_LOGOUT_REQUEST */
 struct soupbin3_packet_logout_request {
 	be16			PacketLength;
 	char			PacketType;
-} packed;
+} __attribute__((packed));
 
 struct soupbin3_session {
 	int				sockfd;

--- a/include/libtrading/proto/xdp_message.h
+++ b/include/libtrading/proto/xdp_message.h
@@ -49,7 +49,7 @@ struct xdp_msg_order_book_add_order {
 	char			Side;
 	char			OrderIDGTCIndicator;
 	char			TradeSession;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_ORDER_BOOK_MODIFY */
 struct xdp_msg_order_book_modify {
@@ -64,7 +64,7 @@ struct xdp_msg_order_book_modify {
 	char			Side;
 	char			OrderIDGTCIndicator;
 	char			ReasonCode;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_ORDER_BOOK_DELETE */
 struct xdp_msg_order_book_delete {
@@ -77,7 +77,7 @@ struct xdp_msg_order_book_delete {
 	char			Side;
 	char			OrderIDGTCIndicator;
 	char			ReasonCode;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_ORDER_BOOK_EXECUTION */
 struct xdp_msg_order_book_execution {
@@ -93,7 +93,7 @@ struct xdp_msg_order_book_execution {
 	char			OrderIDGTCIndicator;
 	char			ReasonCode;
 	le32			TradeID;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_ORDER_BOOK_ADD_ORDER_REFRESH */
 struct xdp_msg_order_book_add_order_refresh {
@@ -109,7 +109,7 @@ struct xdp_msg_order_book_add_order_refresh {
 	char			Side;
 	char			OrderIDGTCIndicator;
 	char			TradeSession;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_TRADE */
 struct xdp_msg_trade {
@@ -132,7 +132,7 @@ struct xdp_msg_trade {
 	le32			AskVolume;
 	le32			BidPrice;
 	le32			BidVolume;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_TRADE_CANCEL_OR_BUST */
 struct xdp_msg_trade_cancel_or_bust {
@@ -143,7 +143,7 @@ struct xdp_msg_trade_cancel_or_bust {
 	le32			SymbolIndex;
 	le32			SymbolSeqNum;
 	le32			OriginalTradeID;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_TRADE_CORRECTION */
 struct xdp_msg_trade_correction {
@@ -162,7 +162,7 @@ struct xdp_msg_trade_correction {
 	char			TradeCond3;
 	char			TradeCond4;
 	char			TradeThroughExempt;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_STOCK_SUMMARY */
 struct xdp_msg_stock_summary {
@@ -176,7 +176,7 @@ struct xdp_msg_stock_summary {
 	le32			Open;
 	le32			Close;
 	le32			TotalVolume;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_PBBO */
 struct xdp_msg_pbbo {
@@ -188,7 +188,7 @@ struct xdp_msg_pbbo {
 	le32			SymbolSeqNum;
 	le32			BidPrice;
 	le32			AskPrice;
-} packed;
+} __attribute__((packed));
 
 /* XDP_MSG_IMBALANCE */
 struct xdp_msg_imbalance {
@@ -208,7 +208,7 @@ struct xdp_msg_imbalance {
 	le32			ContinuousBookClearingPrice;
 	le32			ClosingOnlyClearingPrice;
 	le32			SSRFilingPrice;
-} packed;
+} __attribute__((packed));
 
 int xdp_message_decode(struct buffer *buf, struct xdp_message *msg, size_t size);
 

--- a/include/libtrading/types.h
+++ b/include/libtrading/types.h
@@ -33,8 +33,6 @@ typedef uint16_t bitwise be16;
 typedef uint32_t bitwise be32;
 typedef uint64_t bitwise be64;
 
-#define packed __attribute__ ((packed))
-
 #undef bitwise
 #undef force
 


### PR DESCRIPTION
without the patch getting errors like

In file included from /usr/local/include/libtrading/buffer.h:8:0,
                 from /usr/local/include/libtrading/proto/fix_session.h:10,
                 from /usr/local/include/libtrading/proto/fix_template.h:9,
                 from src/boot/main.cpp:10:
....h:22:18: error: ‘packed’ was not declared in this scope