### PR TITLE
Remove redundant exit() calls after usage().

### DIFF
--- a/tools/cert/micex/forts.c
+++ b/tools/cert/micex/forts.c
@@ -581,7 +581,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/tools/fast/fast_client.c
+++ b/tools/fast/fast_client.c
@@ -346,7 +346,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/tools/fast/fast_parser.c
+++ b/tools/fast/fast_parser.c
@@ -310,7 +310,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/tools/fast/fast_server.c
+++ b/tools/fast/fast_server.c
@@ -326,7 +326,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/tools/fix/fix_client.c
+++ b/tools/fix/fix_client.c
@@ -514,7 +514,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/tools/fix/fix_server.c
+++ b/tools/fix/fix_server.c
@@ -343,7 +343,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/tools/sim/trader.c
+++ b/tools/sim/trader.c
@@ -134,7 +134,6 @@ int main(int argc, char *argv[])
 			break;
 		default: /* '?' */
 			usage();
-			exit(EXIT_FAILURE);
 		}
 	}
 


### PR DESCRIPTION
usage() function already calls exit(EXIT_FAILURE) at its end.