### PR TITLE
FIX: return the number of bytes that are not sent

### DIFF
--- a/include/libtrading/proto/fix_message.h
+++ b/include/libtrading/proto/fix_message.h
@@ -214,6 +214,11 @@ struct fix_message {
 	struct iovec			iov[2];
 };
 
+static inline size_t fix_message_size(struct fix_message *self)
+{
+	return (self->iov[0].iov_len + self->iov[1].iov_len);
+}
+
 enum fix_parse_flag {
 	FIX_PARSE_FLAG_NO_CSUM = 1UL << 0,
 	FIX_PARSE_FLAG_NO_TYPE = 1UL << 1


### PR DESCRIPTION
If non-blocking sockets are used there is a chance
to send a message only partially. Right now there
is no way to find out whether a message is fully
sent. This patch allows to distinguish those two
cases.

fix_session_send() return value:
- negative number indicates an error
- positive number indicates the number of bytes that *are not sent*
- zero indicates success

Signed-off-by: Marat Stanichenko <mstanichenko@gmail.com>