### PR TITLE
fix_template_send() - return unsent bytes, zero if success, <0 on error

### DIFF
--- a/include/libtrading/proto/fix_template.h
+++ b/include/libtrading/proto/fix_template.h
@@ -44,6 +44,8 @@ struct fix_template {
 
 	unsigned long		nr_fields;	 // number of variable length fields to be serialized each time
 	struct fix_field	fields[FIX_MAX_FIELD_NUMBER]; // variable fields array
+
+	struct iovec		iov[4];
 };
 
 struct fix_template_cfg {


### PR DESCRIPTION
similar to @mstanichenko code just for templates.

we may want to consider moving `iov_length()` function to somewhere / reuse it.