### PR TITLE
new template implementation - continous buffer

### DIFF
--- a/include/libtrading/proto/fix_template.h
+++ b/include/libtrading/proto/fix_template.h
@@ -10,15 +10,7 @@ extern "C" {
 
 #define FIX_TEMPLATE_BODY_LEN_ZPAD 4UL
 #define FIX_TEMPLATE_MSG_SEQ_NUM_ZPAD 6UL
-
-// 8=FIX.4.2|9=NNNN|		17 chars
-// 10=NNN|			7  chars
-// 52=YYYYMMDD-HH:MM:SS.sss|	25 chars
-
-#define FIX_MAX_HEAD_BUFFER_SIZE 17UL
-#define FIX_MAX_SYS_BUFFER_SIZE	 80UL
-#define FIX_MAX_CSUM_BUFFER_SIZE 7UL
-#define FIX_MAX_TEMPLATE_TX_BUFFER_SIZE 256UL
+#define FIX_MAX_TEMPLATE_BUFFER_SIZE 1024UL
 
 struct fix_template {
 	char			*marker_body_length;
@@ -26,26 +18,20 @@ struct fix_template {
 	char			*marker_sender_comp_id;
 	char			*marker_sending_time;
 	char			*marker_transact_time;
-	char			*marker_check_sum;
+	char			*marker_const_start;
+	char			*marker_const_end;
 
 	unsigned long		sender_comp_id_len;
+	uint8_t			const_csum;
 
-	struct buffer		head_buf;	 // first two fields
-	struct buffer		const_buf;	 // constant fields
-	struct buffer		sys_buf;	 // SenderCompID + SendingTime only (@TODO TransactTime)
-	struct buffer		body_buf;	 // variable fields
-	struct buffer		csum_buf;	 // checksum  field
-	char			tx_data[FIX_MAX_HEAD_BUFFER_SIZE +
-					FIX_MAX_SYS_BUFFER_SIZE + 
-					2 * FIX_MAX_TEMPLATE_TX_BUFFER_SIZE +
-					FIX_MAX_CSUM_BUFFER_SIZE];
-
-	unsigned long		const_csum;
+	struct buffer		buf;	 // first two fields
+	char			tx_data[FIX_MAX_TEMPLATE_BUFFER_SIZE];
 
 	unsigned long		nr_fields;	 // number of variable length fields to be serialized each time
 	struct fix_field	fields[FIX_MAX_FIELD_NUMBER]; // variable fields array
+	struct fix_field	csum_field;
 
-	struct iovec		iov[4];
+	struct iovec		iov[1];
 };
 
 struct fix_template_cfg {

--- a/include/libtrading/read-write.h
+++ b/include/libtrading/read-write.h
@@ -17,6 +17,8 @@ ssize_t sys_sendmsg(int fd, struct iovec *iov, size_t length, int flags);
 extern io_recv_t io_recv;
 extern io_sendmsg_t io_sendmsg;
 
+size_t iov_byte_length(struct iovec *iov, size_t iov_len);
+
 ssize_t xread(int fd, void *buf, size_t count);
 ssize_t xwrite(int fd, const void *buf, size_t count);
 ssize_t xwritev(int fd, const struct iovec *iov, int iovcnt);

--- a/lib/read-write.c
+++ b/lib/read-write.c
@@ -18,6 +18,17 @@ ssize_t sys_sendmsg(int fd, struct iovec *iov, size_t length, int flags)
 io_recv_t io_recv = &recv;
 io_sendmsg_t io_sendmsg = &sys_sendmsg;
 
+size_t iov_byte_length(struct iovec *iov, size_t iov_len)
+{
+	size_t len = 0;
+	size_t i;
+
+	for (i = 0; i < iov_len; ++i)
+		len += iov[i].iov_len;
+
+	return len;
+}
+
 /* Same as read(2) except that this function never returns EAGAIN or EINTR. */
 ssize_t xread(int fd, void *buf, size_t count)
 {

--- a/tools/fix/fix_perf.c
+++ b/tools/fix/fix_perf.c
@@ -172,18 +172,8 @@ static void fix_template_unparse_benchmark(const int count, struct buffer *rx_bu
 
 	elapsed_nsec = timespec_delta(&start, &end);
 	printf("%-10s %d %f µs/message\n", "format/templ", count, (double)elapsed_nsec/(double)count/1000.0);
-	buffer_printf(rx_buf, "%.*s%.*s%.*s%.*s%.*s",
-		(int)buffer_size(&template->head_buf),	buffer_start(&template->head_buf),
-		(int)buffer_size(&template->const_buf),	buffer_start(&template->const_buf),
-		(int)buffer_size(&template->sys_buf),	buffer_start(&template->sys_buf),
-		(int)buffer_size(&template->body_buf),	buffer_start(&template->body_buf),
-		(int)buffer_size(&template->csum_buf),	buffer_start(&template->csum_buf));
-	/* printf("%.*s%.*s%.*s%.*s%.*s\n",
-		(int)buffer_size(&template->head_buf),	buffer_start(&template->head_buf),
-		(int)buffer_size(&template->const_buf),	buffer_start(&template->const_buf),
-		(int)buffer_size(&template->sys_buf),	buffer_start(&template->sys_buf),
-		(int)buffer_size(&template->body_buf),	buffer_start(&template->body_buf),
-		(int)buffer_size(&template->csum_buf),	buffer_start(&template->csum_buf)); */
+	buffer_printf(rx_buf, "%.*s", (int)buffer_size(&template->buf), buffer_start(&template->buf));
+	// printf("%.*s\n", (int)buffer_size(&template->buf), buffer_start(&template->buf));
 
 	templ_parse = fix_message_parse(rx_msg, &fix_dialects[FIX_4_2], rx_buf, 0);
 	printf("template unparse status: %i\n", templ_parse);


### PR DESCRIPTION
instead of four buffers I managed to do all the template magic in one continuous buffer. this simplifies sending a lot with hardware specific transmit routine.

also preparing template `iovec` in `_unparse` instead of `_send` and moved `iov_byte_length` to a public method.