### PR TITLE
trivial fix for verify_checksum() in case of a stupid error

### DIFF
--- a/lib/proto/fix_message.c
+++ b/lib/proto/fix_message.c
@@ -310,7 +310,7 @@ retry:
 
 static bool verify_checksum(struct fix_message *self, struct buffer *buffer)
 {
-	u8 cksum, actual;
+	int cksum, actual;
 
 	cksum	= fix_uatoi(self->check_sum, NULL);
 


### PR DESCRIPTION
verify_checksum() had a flaw - if one forgot to do %256 on checksum but the checksum itself is correct but just >256 then verify was returning true incorrectly