### PR TITLE
Fix warnings

### DIFF
--- a/include/libtrading/buffer.h
+++ b/include/libtrading/buffer.h
@@ -57,34 +57,45 @@ static inline char buffer_get_char(struct buffer *self)
 {
 	return buffer_get_8(self);
 }
+
 static inline u16 buffer_get_le16(struct buffer *self)
 {
-	return buffer_get_8(self) | buffer_get_8(self) << 8;
+	u16 x = 0;
+	x |= (u16)buffer_get_8(self);
+	x |= (u16)buffer_get_8(self) << 8;
+	return x;
 }
 
 static inline u32 buffer_get_le32(struct buffer *self)
 {
-	return buffer_get_8(self)
-		| buffer_get_8(self) << 8
-		| buffer_get_8(self) << 16
-		| buffer_get_8(self) << 24;
+	u32 x = 0;
+	x |= (u32)buffer_get_8(self);
+	x |= (u32)buffer_get_8(self) << 8;
+	x |= (u32)buffer_get_8(self) << 16;
+	x |= (u32)buffer_get_8(self) << 24;
+	return x;
 }
 
 static inline uint64_t buffer_get_le64(struct buffer *self)
 {
-	return (uint64_t) buffer_get_8(self)
-		| (uint64_t) buffer_get_8(self) << 8
-		| (uint64_t) buffer_get_8(self) << 16
-		| (uint64_t) buffer_get_8(self) << 24
-		| (uint64_t) buffer_get_8(self) << 32
-		| (uint64_t) buffer_get_8(self) << 40
-		| (uint64_t) buffer_get_8(self) << 48
-		| (uint64_t) buffer_get_8(self) << 56;
+	uint64_t x = 0;
+	x |= (uint64_t)buffer_get_8(self);
+	x |= (uint64_t)buffer_get_8(self) << 8;
+	x |= (uint64_t)buffer_get_8(self) << 16;
+	x |= (uint64_t)buffer_get_8(self) << 24;
+	x |= (uint64_t)buffer_get_8(self) << 32;
+	x |= (uint64_t)buffer_get_8(self) << 40;
+	x |= (uint64_t)buffer_get_8(self) << 48;
+	x |= (uint64_t)buffer_get_8(self) << 56;
+	return x;
 }
 
 static inline u16 buffer_get_be16(struct buffer *self)
 {
-	return buffer_get_8(self) << 8 | buffer_get_8(self);
+	u16 x = 0;
+	x |= (u16)buffer_get_8(self) << 8;
+	x |= (u16)buffer_get_8(self);
+	return x;
 }
 
 static inline void buffer_get_n(struct buffer *self, int n, char *dst)

--- a/lib/proto/fast_template.c
+++ b/lib/proto/fast_template.c
@@ -270,6 +270,9 @@ static int fast_sequence_init(xmlNodePtr node, struct fast_field *field)
 	while (node && node->type != XML_ELEMENT_NODE)
 		node = node->next;
 
+	if (node == NULL)
+		goto exit;
+
 	if (xmlStrcmp(node->name, (const xmlChar *)"length"))
 		goto exit;
 

--- a/lib/proto/fast_template.c
+++ b/lib/proto/fast_template.c
@@ -394,9 +394,6 @@ static int fast_field_init(xmlNodePtr node, struct fast_field *field)
 	if (ret)
 		goto exit;
 
-	if (field->type == FAST_TYPE_DECIMAL)
-		ret = 0;
-
 	ret = fast_presence_init(node, field);
 	if (ret)
 		goto exit;

--- a/tools/fix/test.c
+++ b/tools/fix/test.c
@@ -350,7 +350,7 @@ void fprintmsg_iov(FILE *stream, struct fix_message *msg)
 	for (i = 0; i < 2; ++i) {
 		const char *start = msg->iov[i].iov_base;
 		unsigned int len = msg->iov[i].iov_len;
-		const char *end = start;
+		const char *end;
 
 		while ((end = memchr(start, 0x01, len))) {
 			fprintf(stdout, "%c%.*s", delim, (int)(end - start), start);


### PR DESCRIPTION
Clang produces a few warnings that seem worth fixing.

I also noticed an unsettling pattern in `buffer.h`: The order of evaluation of the arguments to `operator|` is unspecified and should not be relied on.