### PR TITLE
FAST: 64-bit signed integers may consume up to 10 bytes in a stream

### DIFF
--- a/lib/proto/fast_message.c
+++ b/lib/proto/fast_message.c
@@ -40,7 +40,7 @@ partial:
 
 static int parse_int(struct buffer *buffer, i64 *value)
 {
-	const int bytes = 9;
+	const int bytes = 10;
 	i64 result;
 	int i;
 	u8 c;


### PR DESCRIPTION
A signed integer that takes N bytes in a stream is at least
7 * (N - 1) bits long. Therefore it must not take more than
10 bytes in the FAST stream. There are cases when an integer
may take exactly 10 bytes.

Example,
mandatory int64 field = -9223372036854775807 is decoded as
0x7F 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x81

Signed-off-by: Marat Stanichenko <mstanichenko@gmail.com>