### PR TITLE
Added header for MoldUDP64

### DIFF
--- a/include/libtrading/proto/omx_moldudp_message.h
+++ b/include/libtrading/proto/omx_moldudp_message.h
@@ -33,6 +33,37 @@ static inline void *omx_moldudp_message_payload(struct omx_moldudp_message *msg)
 	return (void *) msg + sizeof(struct omx_moldudp_message);
 }
 
+/*
+ * MoldUDP64
+ */
+
+struct omx_moldudp64_header {
+	char			Session[10];
+	le64			SequenceNumber;
+	le16			MessageCount;
+} __attribute__((packed));
+
+struct omx_moldudp64_message {
+	le16			MessageLength;
+} __attribute__((packed));
+
+struct omx_moldudp64_request {
+	char			Session[10];
+	le64			SequenceNumber;
+	le16			RequestedMessageCount;
+} __attribute__((packed));
+
+static inline struct omx_moldudp64_message *omx_moldudp64_payload(struct omx_moldudp64_header *msg)
+{
+	return (void *) msg + sizeof(struct omx_moldudp64_header);
+}
+
+static inline void *omx_moldudp64_message_payload(struct omx_moldudp64_message *msg)
+{
+	return (void *) msg + sizeof(struct omx_moldudp64_message);
+}
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The newer MoldUDP64 header changed the size of the SequenceNumber from 4 bytes to 8 bytes. The header file now has the definitions for both MoldUDP and MoldUDP64 headers.

I also added the MoldUDP64 spec to the wiki spec page: https://github.com/libtrading/libtrading/wiki/Technical-Specifications