### PR TITLE
avoid undefined behaviour in pointer arithmetic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ EXTRA_WARNINGS += -Wmissing-prototypes
 EXTRA_WARNINGS += -Wnested-externs
 EXTRA_WARNINGS += -Wold-style-definition
 EXTRA_WARNINGS += -Wstrict-prototypes
+EXTRA_WARNINGS += -Wpointer-arith
 
 # Compile flags
 CFLAGS		:= -I$(CURDIR)/include -Wall $(EXTRA_WARNINGS) $(CFLAGS_WERROR) -g -O3 -std=gnu99 -fPIC

--- a/include/libtrading/proto/boe_message.h
+++ b/include/libtrading/proto/boe_message.h
@@ -185,7 +185,7 @@ int boe_message_decode(struct buffer *buf, struct boe_message *msg, size_t size)
 
 static inline void *boe_message_payload(struct boe_message *msg)
 {
-	return (void *) msg + sizeof(struct boe_header);
+	return (char *) msg + sizeof(struct boe_header);
 }
 
 #ifdef __cplusplus

--- a/include/libtrading/proto/mbt_quote_message.h
+++ b/include/libtrading/proto/mbt_quote_message.h
@@ -49,7 +49,7 @@ struct mbt_quote_message *mbt_quote_message_decode(struct buffer *buf);
 
 static inline void *mbt_quote_message_payload(struct mbt_quote_message *msg)
 {
-	return (void *) msg + sizeof(struct mbt_quote_message);
+	return (char *) msg + sizeof(struct mbt_quote_message);
 }
 
 #ifdef __cplusplus

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -18,7 +18,7 @@ struct buffer *buffer_new(unsigned long capacity)
 	if (!buf)
 		return NULL;
 
-	buf->data	= (void *) buf + sizeof(*buf);
+	buf->data	= (char *) buf + sizeof(*buf);
 	buf->capacity	= capacity;
 	buf->start	= 0;
 	buf->end	= 0;

--- a/lib/proto/soupbin3_session.c
+++ b/lib/proto/soupbin3_session.c
@@ -36,7 +36,7 @@ void soupbin3_session_delete(struct soupbin3_session *session)
 static int soupbin3_packet_decode(struct buffer *buf, u16 len, struct soupbin3_packet *packet)
 {
 	size_t size;
-	void *start;
+	char *start;
 
 	start = buffer_start(buf);
 


### PR DESCRIPTION
Pointer arithmetic on "void *" type is only allowed in GNU C and supported
by GCC as a language extension, but might be undefined in other compilers.

See https://gcc.gnu.org/onlinedocs/gcc/Pointer-Arith.html for details.