### PR TITLE
docs: fix simple typo, unknow -> unknown

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,7 +139,7 @@ the already existed
 The choosen dialect is stored within a session structure and passed through
 configuration parameters. Each time a FIX message is being received a tag_type
 function is invoked. Known fields are parsed in accordance with their datatypes,
-unknow fields are stored as strings.
+unknown fields are stored as strings.
 
 ### FIX client example
 


### PR DESCRIPTION
There is a small typo in docs/quickstart.md.

Should read `unknown` rather than `unknow`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md